### PR TITLE
Issue 22: initial commit

### DIFF
--- a/src/main/java/com/infusion/relnotesgen/ReleaseNotesModel.java
+++ b/src/main/java/com/infusion/relnotesgen/ReleaseNotesModel.java
@@ -1,12 +1,14 @@
 package com.infusion.relnotesgen;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.collect.*;
 import com.infusion.relnotesgen.util.JiraIssueSearchType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -58,14 +60,14 @@ public class ReleaseNotesModel {
         this.knownIssues = knownIssues;
         this.errors = errors;
 
-        uniqueDefects = generateUniqueDefects(issuesByCategory, commitsWithDefectIds);
+        uniqueDefects = generateUniqueDefects(generateValidIssuesByCategory(issuesByCategory), commitsWithDefectIds);
         ImmutableSortedSet<String> uniqueJiras = generateUniqueJiras(issuesByCategory);
 
         jqlLink = generateUrlEncodedJqlString(generateJqlUrl(uniqueJiras));
         knownIssuesJqlLink = generateUrlEncodedJqlString(generateJqlUrl(configuration.getKnownIssues()));
     }
 
-	private ImmutableSortedSet<String> generateUniqueJiras(final ImmutableMap<String, ImmutableSet<ReportJiraIssueModel>> issuesByCategory) {
+    private ImmutableSortedSet<String> generateUniqueJiras(final ImmutableMap<String, ImmutableSet<ReportJiraIssueModel>> issuesByCategory) {
 		return FluentIterable
                 .from(issuesByCategory.values())
                 .transformAndConcat(new Function<ImmutableSet<ReportJiraIssueModel>, List<String>>() {
@@ -92,6 +94,18 @@ public class ReleaseNotesModel {
                 );
 	}
 
+    private ImmutableMap<String, ImmutableSet<ReportJiraIssueModel>> generateValidIssuesByCategory(
+            ImmutableMap<String, ImmutableSet<ReportJiraIssueModel>> issuesByCategory) {
+        Map<String, ImmutableSet<ReportJiraIssueModel>> validIssuesByCategoryTemp = new HashMap<String, ImmutableSet<ReportJiraIssueModel>>();
+        validIssuesByCategoryTemp.putAll(issuesByCategory);
+        for (JiraIssueSearchType curr : JiraIssueSearchType.values()) {
+            if (!curr.isValid()) {
+                validIssuesByCategoryTemp.remove(curr.title());
+            }
+        }
+        return ImmutableMap.copyOf(validIssuesByCategoryTemp);
+    }
+
 	private ImmutableSortedSet<String> generateUniqueDefects(final ImmutableMap<String, ImmutableSet<ReportJiraIssueModel>> issuesByCategory,
 			final ImmutableSet<ReportCommitModel> commitsWithDefectIds) {
 		return FluentIterable
@@ -108,14 +122,7 @@ public class ReleaseNotesModel {
                                 }
                             }).toList();
                     }
-                }).append(FluentIterable.from(commitsWithDefectIds)
-	                    .transformAndConcat(new Function<ReportCommitModel, ImmutableSet<String>>() {
-	                        @Override
-	                        public ImmutableSet<String> apply(ReportCommitModel reportCommitModel) {
-	                            return reportCommitModel.getDefectIds();
-	                        }
-	                    })
-                )
+                })
                 .transform(new Function<String, String>() {
                     @Override
                     public String apply(String s) {
@@ -161,7 +168,12 @@ public class ReleaseNotesModel {
     }
 	
     public boolean categoryNameIsInvalid(final String categoryName) {
-    	return JiraIssueSearchType.INVALID_STATE.title().equals(categoryName) || JiraIssueSearchType.INVALID_FIX_VERSION.title().equals(categoryName);
+        for (JiraIssueSearchType curr : JiraIssueSearchType.values()) {
+            if (curr.title().equals(categoryName) && !curr.isValid()) {
+                return true;
+            }
+        }
+        return false;
     }
 
 	public List<String> getIssueCategoryNamesList() {
@@ -179,7 +191,13 @@ public class ReleaseNotesModel {
     }
 
     public int getTotalInvalidIssueCount() {
-        return getIssueCountByCategoryName(JiraIssueSearchType.INVALID_FIX_VERSION.title()) + getIssueCountByCategoryName(JiraIssueSearchType.INVALID_STATE.title());
+        int invalidCount = 0;
+        for (JiraIssueSearchType curr : JiraIssueSearchType.values()) {
+            if (!curr.isValid()) {
+                invalidCount += getIssueCountByCategoryName(curr.title());
+            }
+        }
+        return invalidCount;
     }
 	
 	

--- a/src/main/java/com/infusion/relnotesgen/util/JiraIssueSearchType.java
+++ b/src/main/java/com/infusion/relnotesgen/util/JiraIssueSearchType.java
@@ -1,19 +1,25 @@
 package com.infusion.relnotesgen.util;
 
 public enum JiraIssueSearchType {
-	GENERIC ("Generic"), 
-	INVALID_FIX_VERSION ("Invalid Fix Version(s)"), 
-    INVALID_STATE ("Invalid State"), 
-	FIX_VERSION ("FixVersion"), 
-	KNOWN_ISSUE ("KnownIssue");
+	GENERIC ("Generic", true), 
+	INVALID_FIX_VERSION ("Invalid Fix Version(s)", false), 
+    INVALID_STATE ("Invalid State", false), 
+	FIX_VERSION ("FixVersion", true), 
+	KNOWN_ISSUE ("KnownIssue", true);
     
     private String title;
+    private boolean isValid;
     
-    JiraIssueSearchType(String title) {
+    JiraIssueSearchType(String title, boolean isValid) {
         this.title = title;
+        this.isValid = isValid;
     }
     
     public String title() {
         return title;
+    }
+    
+    public boolean isValid() {
+        return isValid;
     }
 }


### PR DESCRIPTION
- add valid flad to JiraIssueSearchType enum
- add method to generate the valid issues by category which is used to set the uniqueDefects (all defects in UI)
- use valid flags to make methods more dynamic
- remove commits with defects from uniquedefects (add defects in UI)